### PR TITLE
feat(schemas): refine additional tool input schemas

### DIFF
--- a/src/tools/accounts_update.ts
+++ b/src/tools/accounts_update.ts
@@ -3,7 +3,13 @@ import type { paths } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
-const InputSchema = z.any();
+const InputSchema = z.object({
+  id: z.string().min(1).describe('Account ID'),
+  name: z.string().optional().describe('Optional new account name'),
+  balance: z.number().optional().describe('Optional new balance'),
+}).refine(data => !!(data.name !== undefined || data.balance !== undefined), {
+  message: 'At least one updatable field (name or balance) must be provided',
+});
 
 // RESPONSE_TYPE: any
 type Output = any; // refine using generated types (paths['/accounts']['put'])

--- a/src/tools/budgets_setAmount.ts
+++ b/src/tools/budgets_setAmount.ts
@@ -3,7 +3,11 @@ import type { paths } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
-const InputSchema = z.object({  });
+const InputSchema = z.object({
+  month: z.string().min(1).describe('Month in YYYY-MM format'),
+  categoryId: z.string().min(1).describe('Category ID to set'),
+  amount: z.number().describe('Amount to set for the budget category'),
+});
 
 // RESPONSE_TYPE: any
 type Output = any; // refine using generated types (paths['/budgets/month']['post'])

--- a/src/tools/categories_create.ts
+++ b/src/tools/categories_create.ts
@@ -3,7 +3,10 @@ import type { paths } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
-const InputSchema = z.object({  });
+const InputSchema = z.object({
+  name: z.string().min(1).describe('Category name'),
+  parentId: z.string().optional(),
+});
 
 // RESPONSE_TYPE: string
 type Output = any; // refine using generated types (paths['/categories']['post'])

--- a/src/tools/payees_create.ts
+++ b/src/tools/payees_create.ts
@@ -3,7 +3,10 @@ import type { paths } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
-const InputSchema = z.object({  });
+const InputSchema = z.object({
+  name: z.string().min(1).describe('Payee name'),
+  notes: z.string().optional(),
+});
 
 // RESPONSE_TYPE: string
 type Output = any; // refine using generated types (paths['/payees']['post'])

--- a/tests/unit/accounts_update.test.js
+++ b/tests/unit/accounts_update.test.js
@@ -1,0 +1,29 @@
+console.log('Running JS smoke tests for accounts_update');
+
+(async () => {
+  const mod = await import('../../dist/src/tools/accounts_update.js');
+  const tool = mod.default;
+  const adapterMod = await import('../../dist/src/lib/actual-adapter.js');
+
+  try {
+    tool.inputSchema.parse({ id: 'a1' });
+    console.error('Expected parse to fail when no updatable fields are provided');
+    process.exit(2);
+  } catch (e) {
+    console.log('Empty update correctly rejected');
+  }
+
+  const good = { id: 'a1', name: 'Updated name' };
+  const parsed = tool.inputSchema.parse(good);
+  console.log('Parsed OK:', parsed);
+
+  const orig = adapterMod.default.updateAccount;
+  adapterMod.default.updateAccount = async (id, fields) => ({ id, ...fields });
+  const res = await tool.call(good);
+  if (!res || !res.result || res.result.name !== 'Updated name') {
+    console.error('Unexpected result from accounts_update:', res);
+    process.exit(2);
+  }
+  adapterMod.default.updateAccount = orig;
+  console.log('JS accounts_update smoke tests passed');
+})();

--- a/tests/unit/budgets_setAmount.test.js
+++ b/tests/unit/budgets_setAmount.test.js
@@ -1,0 +1,29 @@
+console.log('Running JS smoke tests for budgets_setAmount');
+
+(async () => {
+  const mod = await import('../../dist/src/tools/budgets_setAmount.js');
+  const tool = mod.default;
+  const adapterMod = await import('../../dist/src/lib/actual-adapter.js');
+
+  try {
+    tool.inputSchema.parse({});
+    console.error('Expected parse to fail for empty input');
+    process.exit(2);
+  } catch (e) {
+    console.log('Empty input correctly failed');
+  }
+
+  const good = { month: '2025-10', categoryId: 'cat_1', amount: 123 };
+  const parsed = tool.inputSchema.parse(good);
+  console.log('Parsed OK:', parsed);
+
+  const orig = adapterMod.default.setBudgetAmount;
+  adapterMod.default.setBudgetAmount = async (month, cat, amount) => ({ month, cat, amount });
+  const res = await tool.call(good);
+  if (!res || !res.result) {
+    console.error('Unexpected result from budgets_setAmount:', res);
+    process.exit(2);
+  }
+  adapterMod.default.setBudgetAmount = orig;
+  console.log('JS budgets_setAmount smoke tests passed');
+})();

--- a/tests/unit/categories_create.test.js
+++ b/tests/unit/categories_create.test.js
@@ -1,0 +1,29 @@
+console.log('Running JS smoke tests for categories_create');
+
+(async () => {
+  const mod = await import('../../dist/src/tools/categories_create.js');
+  const tool = mod.default;
+  const adapterMod = await import('../../dist/src/lib/actual-adapter.js');
+
+  try {
+    tool.inputSchema.parse({});
+    console.error('Expected parse to fail for empty input');
+    process.exit(2);
+  } catch (e) {
+    console.log('Empty input correctly failed');
+  }
+
+  const good = { name: 'Groceries' };
+  const parsed = tool.inputSchema.parse(good);
+  console.log('Parsed OK:', parsed);
+
+  const orig = adapterMod.default.createCategory;
+  adapterMod.default.createCategory = async (c) => 'cat_1';
+  const res = await tool.call(good);
+  if (!res || !res.result) {
+    console.error('Unexpected result from categories_create:', res);
+    process.exit(2);
+  }
+  adapterMod.default.createCategory = orig;
+  console.log('JS categories_create smoke tests passed');
+})();

--- a/tests/unit/generated_tools.smoke.test.js
+++ b/tests/unit/generated_tools.smoke.test.js
@@ -40,14 +40,16 @@ console.log('Running generated tools smoke tests');
   if (mod && mod.default) mod = mod.default;
       const inputExample = {};
       // Provide minimal examples for known tools
-      if (name.includes('transactions_create')) inputExample.accountId = 'acct_1', inputExample.amount = 12.34;
-      if (name.includes('transactions_import')) inputExample.accountId = 'acct_1', inputExample.transactions = [{ amount: 100 }];
-      if (name.includes('transactions_get')) inputExample.accountId = 'acct_1';
-      if (name.includes('accounts_get_balance')) inputExample.id = 'acct_1';
-      if (name.includes('accounts_create')) inputExample.name = 'New';
-      if (name.includes('categories_create')) inputExample.name = 'Food', inputExample.group_id = 'g1';
-      if (name.includes('payees_create')) inputExample.name = 'Kroger';
-      if (name.includes('budgets')) inputExample.month = '2025-10';
+  if (name.includes('transactions_create')) inputExample.accountId = 'acct_1', inputExample.amount = 12.34;
+  if (name.includes('transactions_import')) inputExample.accountId = 'acct_1', inputExample.transactions = [{ amount: 100 }];
+  if (name.includes('transactions_get')) inputExample.accountId = 'acct_1';
+  if (name.includes('accounts_get_balance')) inputExample.id = 'acct_1';
+  if (name.includes('accounts_create')) inputExample.name = 'New';
+  if (name.includes('accounts_update')) inputExample.id = 'acct_1', inputExample.name = 'Updated Name';
+  if (name.includes('categories_create')) inputExample.name = 'Food';
+  if (name.includes('payees_create')) inputExample.name = 'Kroger';
+  if (name.includes('budgets_setAmount')) inputExample.month = '2025-10', inputExample.categoryId = 'cat_1', inputExample.amount = 100;
+  if (name.includes('budgets_getMonth')) inputExample.month = '2025-10';
 
       // Validate input parsing
   try { mod.inputSchema.parse(inputExample); } catch (e) { /* ignore parse errors for optional inputs */ }

--- a/tests/unit/payees_create.test.js
+++ b/tests/unit/payees_create.test.js
@@ -1,0 +1,29 @@
+console.log('Running JS smoke tests for payees_create');
+
+(async () => {
+  const mod = await import('../../dist/src/tools/payees_create.js');
+  const tool = mod.default;
+  const adapterMod = await import('../../dist/src/lib/actual-adapter.js');
+
+  try {
+    tool.inputSchema.parse({});
+    console.error('Expected parse to fail for empty input');
+    process.exit(2);
+  } catch (e) {
+    console.log('Empty input correctly failed');
+  }
+
+  const good = { name: 'Amazon' };
+  const parsed = tool.inputSchema.parse(good);
+  console.log('Parsed OK:', parsed);
+
+  const orig = adapterMod.default.createPayee;
+  adapterMod.default.createPayee = async (p) => 'payee_1';
+  const res = await tool.call(good);
+  if (!res || !res.result) {
+    console.error('Unexpected result from payees_create:', res);
+    process.exit(2);
+  }
+  adapterMod.default.createPayee = orig;
+  console.log('JS payees_create smoke tests passed');
+})();

--- a/tests/unit/transactions_get.test.js
+++ b/tests/unit/transactions_get.test.js
@@ -1,0 +1,20 @@
+console.log('Running JS smoke tests for transactions_get');
+
+(async () => {
+  const mod = await import('../../dist/src/tools/transactions_get.js');
+  const tool = mod.default;
+  const adapterMod = await import('../../dist/src/lib/actual-adapter.js');
+
+  const parsed = tool.inputSchema.parse({ accountId: 'a1', startDate: '2025-10-01', endDate: '2025-10-31' });
+  console.log('Parsed OK:', parsed);
+
+  const orig = adapterMod.default.getTransactions;
+  adapterMod.default.getTransactions = async (accountId, start, end) => [{ id: 't1', accountId, amount: 10, date: start }];
+  const res = await tool.call({ accountId: 'a1', startDate: '2025-10-01', endDate: '2025-10-31' });
+  if (!res || !res.result || !Array.isArray(res.result)) {
+    console.error('Unexpected result from transactions_get:', res);
+    process.exit(2);
+  }
+  adapterMod.default.getTransactions = orig;
+  console.log('JS transactions_get smoke tests passed');
+})();


### PR DESCRIPTION
Refine input schemas for accounts_update, categories_create, payees_create, budgets_setAmount and add per-tool smoke tests; update generated-tools smoke test examples.