### PR TITLE
chore(types): refine tool output types where OpenAPI schemas exist

### DIFF
--- a/src/tools/accounts_create.ts
+++ b/src/tools/accounts_create.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
@@ -10,7 +10,7 @@ const InputSchema = z.object({
 });
 
 // RESPONSE_TYPE: string
-type Output = any; // refine using generated types (paths['/accounts']['post'])
+type Output = string;
 
 const tool: ToolDefinition = {
   name: 'actual.accounts.create',

--- a/src/tools/accounts_get_balance.ts
+++ b/src/tools/accounts_get_balance.ts
@@ -6,7 +6,7 @@ import adapter from '../lib/actual-adapter.js';
 const InputSchema = z.object({ "id": z.string().optional(), "cutoff": z.string().optional() });
 
 // RESPONSE_TYPE: number
-type Output = any; // refine using generated types (paths['/accounts/balance']['get'])
+type Output = number;
 
 const tool: ToolDefinition = {
   name: 'actual.accounts.get.balance',

--- a/src/tools/accounts_list.ts
+++ b/src/tools/accounts_list.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({});
 
-type Output = any; // refine using generated types (paths['/accounts']['get'])
+type Output = components['schemas']['Account'][];
 
 const tool: ToolDefinition = {
   name: 'actual.accounts.list',

--- a/src/tools/accounts_update.ts
+++ b/src/tools/accounts_update.ts
@@ -12,7 +12,7 @@ const InputSchema = z.object({
 });
 
 // RESPONSE_TYPE: any
-type Output = any; // refine using generated types (paths['/accounts']['put'])
+type Output = void | null;
 
 const tool: ToolDefinition = {
   name: 'actual.accounts.update',

--- a/src/tools/budgets_getMonth.ts
+++ b/src/tools/budgets_getMonth.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({ "month": z.string().optional() });
 
 // RESPONSE_TYPE: object
-type Output = any; // refine using generated types (paths['/budgets/month']['get'])
+type Output = any; // no detailed schema in OpenAPI fragment
 
 const tool: ToolDefinition = {
   name: 'actual.budgets.getMonth',

--- a/src/tools/budgets_getMonths.ts
+++ b/src/tools/budgets_getMonths.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({});
 
 // RESPONSE_TYPE: array
-type Output = any; // refine using generated types (paths['/budgets/months']['get'])
+type Output = string[];
 
 const tool: ToolDefinition = {
   name: 'actual.budgets.getMonths',

--- a/src/tools/budgets_setAmount.ts
+++ b/src/tools/budgets_setAmount.ts
@@ -10,7 +10,7 @@ const InputSchema = z.object({
 });
 
 // RESPONSE_TYPE: any
-type Output = any; // refine using generated types (paths['/budgets/month']['post'])
+type Output = void | null;
 
 const tool: ToolDefinition = {
   name: 'actual.budgets.setAmount',

--- a/src/tools/categories_create.ts
+++ b/src/tools/categories_create.ts
@@ -9,7 +9,7 @@ const InputSchema = z.object({
 });
 
 // RESPONSE_TYPE: string
-type Output = any; // refine using generated types (paths['/categories']['post'])
+type Output = string;
 
 const tool: ToolDefinition = {
   name: 'actual.categories.create',

--- a/src/tools/categories_get.ts
+++ b/src/tools/categories_get.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({});
 
 // RESPONSE_TYPE: array
-type Output = any; // refine using generated types (paths['/categories']['get'])
+type Output = Record<string, any>[];
 
 const tool: ToolDefinition = {
   name: 'actual.categories.get',

--- a/src/tools/payees_create.ts
+++ b/src/tools/payees_create.ts
@@ -9,7 +9,7 @@ const InputSchema = z.object({
 });
 
 // RESPONSE_TYPE: string
-type Output = any; // refine using generated types (paths['/payees']['post'])
+type Output = string;
 
 const tool: ToolDefinition = {
   name: 'actual.payees.create',

--- a/src/tools/payees_get.ts
+++ b/src/tools/payees_get.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({});
 
 // RESPONSE_TYPE: array
-type Output = any; // refine using generated types (paths['/payees']['get'])
+type Output = Record<string, any>[];
 
 const tool: ToolDefinition = {
   name: 'actual.payees.get',

--- a/src/tools/transactions_create.ts
+++ b/src/tools/transactions_create.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
@@ -10,7 +10,7 @@ const InputSchema = z.object({
   date: z.string().optional(),
 });
 
-type Output = any; // TODO: refine using paths['/transactions']['post']['responses']['200']
+type Output = components['schemas']['Transaction'];
 
 const tool: ToolDefinition = {
   name: 'actual.transactions.create',

--- a/src/tools/transactions_get.ts
+++ b/src/tools/transactions_get.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
 const InputSchema = z.object({ "accountId": z.string().optional(), "startDate": z.string().optional(), "endDate": z.string().optional() });
 
 // RESPONSE_TYPE: Transaction[]
-type Output = any; // refine using generated types (paths['/transactions']['get'])
+type Output = components['schemas']['Transaction'][];
 
 const tool: ToolDefinition = {
   name: 'actual.transactions.get',

--- a/src/tools/transactions_import.ts
+++ b/src/tools/transactions_import.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import type { paths } from '../../generated/actual-client/types.js';
+import type { paths, components } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
 import adapter from '../lib/actual-adapter.js';
 
@@ -16,7 +16,7 @@ const InputSchema = z.union([
 ]);
 
 // RESPONSE_TYPE: object
-type Output = any; // refine using generated types (paths['/transactions/import']['post'])
+type Output = { added: string[]; updated: string[]; errors: string[] };
 
 const tool: ToolDefinition = {
   name: 'actual.transactions.import',


### PR DESCRIPTION
Refine tool Output types using generated OpenAPI types where available (accounts, transactions, budgets, categories, payees).