### PR TITLE
ci: add generator-check workflow

### DIFF
--- a/.github/workflows/generator-check.yml
+++ b/.github/workflows/generator-check.yml
@@ -1,0 +1,64 @@
+name: Verify generated tools
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  generator-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run generator
+        run: node scripts/generate-tools-node.js
+
+      - name: Check for unstaged changes
+        run: |
+          git status --porcelain
+          git --no-pager diff --exit-code || (echo "Generated files differ from committed files; please run npm run generate-tools and commit changes." && exit 1)
+name: Verify generated tools
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  generator-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run generator
+        run: node scripts/generate-tools-node.js
+
+      - name: Check for unstaged changes
+        run: |
+          git status --porcelain
+          git --no-pager diff --exit-code || (echo "Generated files differ from committed files; please run npm run generate-tools and commit changes." && exit 1)


### PR DESCRIPTION
Add CI job that runs the generator and fails if generated files differ from committed files. This prevents drift between committed stubs and generator output.