### PR TITLE
chore(types): remove low-risk ad-hoc any in tools

### DIFF
--- a/src/tools/accounts_create.ts
+++ b/src/tools/accounts_create.ts
@@ -15,7 +15,8 @@ const tool: ToolDefinition = {
   call: async (args: unknown, _meta?: any) => {
     const input = InputSchema.parse(args || {});
     // call adapter to create account; adapter returns an id-like string
-    const result = await adapter.createAccount(input as any, (input as any).balance);
+    const accountPayload = { id: input.id, name: input.name, balance: input.balance } as any;
+    const result = await adapter.createAccount(accountPayload, input.balance);
     return { result };
   },
 };

--- a/src/tools/accounts_get_balance.ts
+++ b/src/tools/accounts_get_balance.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.accounts.get.balance',
   description: "Get account balance",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     const input = InputSchema.parse(args || {});
     const result = await adapter.getAccountBalance(input.id ?? '', input.cutoff);
     return { result };

--- a/src/tools/accounts_list.ts
+++ b/src/tools/accounts_list.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.accounts.list',
   description: "List all accounts",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     // call adapter.getAccounts with no args
     const result = await adapter.getAccounts();
     return { result };

--- a/src/tools/budgets_getMonth.ts
+++ b/src/tools/budgets_getMonth.ts
@@ -12,11 +12,11 @@ const tool: ToolDefinition = {
   name: 'actual.budgets.getMonth',
   description: "Get budget month",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
-    const input = InputSchema.parse(args || {});
-    const result = await adapter.getBudgetMonth(input.month);
-    return { result };
-  },
+    call: async (args: unknown, _meta?: any) => {
+      const input = InputSchema.parse(args || {});
+      const result = await adapter.getBudgetMonth(input.month);
+      return { result };
+    },
 };
 
 export default tool;

--- a/src/tools/budgets_getMonths.ts
+++ b/src/tools/budgets_getMonths.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.budgets.getMonths',
   description: "Get budget months",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     InputSchema.parse(args || {});
     const result = await adapter.getBudgetMonths();
     return { result };

--- a/src/tools/categories_get.ts
+++ b/src/tools/categories_get.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.categories.get',
   description: "Get categories",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     InputSchema.parse(args || {});
     const result = await adapter.getCategories();
     return { result };

--- a/src/tools/payees_get.ts
+++ b/src/tools/payees_get.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.payees.get',
   description: "Get payees",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     InputSchema.parse(args || {});
     const result = await adapter.getPayees();
     return { result };

--- a/src/tools/transactions_create.ts
+++ b/src/tools/transactions_create.ts
@@ -14,9 +14,9 @@ const tool: ToolDefinition = {
   inputSchema: InputSchema,
   call: async (args: unknown, _meta?: any) => {
     // validate input
-    const input = InputSchema.parse(args || {});
-    // call adapter.addTransactions (wrap single transaction into array)
-    const result = await adapter.addTransactions([input as any]);
+  const input = InputSchema.parse(args || {});
+  // call adapter.addTransactions (wrap single transaction into array)
+  const result = await adapter.addTransactions([input]);
     return { result };
 
   },

--- a/src/tools/transactions_get.ts
+++ b/src/tools/transactions_get.ts
@@ -12,7 +12,7 @@ const tool: ToolDefinition = {
   name: 'actual.transactions.get',
   description: "Get transactions for an account and date range",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     const input = InputSchema.parse(args || {});
     const result = await adapter.getTransactions(input.accountId, input.startDate, input.endDate);
     return { result };

--- a/src/tools/transactions_import.ts
+++ b/src/tools/transactions_import.ts
@@ -16,18 +16,18 @@ const tool: ToolDefinition = {
   name: 'actual.transactions.import',
   description: "Import transactions (reconcile, avoid duplicates)",
   inputSchema: InputSchema,
-  call: async (args: any, _meta?: any) => {
+  call: async (args: unknown, _meta?: any) => {
     const parsed = InputSchema.parse(args || {});
     // allow either { accountId, txs } or raw txs
     let accountId: string | undefined;
     let txs: unknown;
     if (parsed && typeof parsed === 'object' && 'txs' in (parsed as Record<string, unknown>)) {
-      accountId = (parsed as any).accountId;
-      txs = (parsed as any).txs;
+  accountId = (parsed as any).accountId;
+  txs = (parsed as any).txs;
     } else {
       txs = parsed;
     }
-    const result = await adapter.importTransactions(accountId, txs as any);
+  const result = await adapter.importTransactions(accountId, txs);
     return { result };
 
   },


### PR DESCRIPTION
This PR tightens several tool call signatures from args:any to args:unknown and removes trivial 'as any' casts after zod parsing. All generated tools smoke tests pass locally.