### PR TITLE
fix: prevent server crash when data dir is not writable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,17 @@ process.on('unhandledRejection', (reason, promise) => {
     // primary fix lives in httpServer.ts (.catch on initPromise); this allow-list
     // entry is defence-in-depth so any future deferred-promise leak in the same
     // family also fails non-fatally.
-    reasonStr.includes('Authentication failed:')
+    reasonStr.includes('Authentication failed:') ||
+    // EACCES/EPERM from @actual-app/api's internal worker during budget download
+    // (e.g. when MCP_BRIDGE_DATA_DIR is not writable). The primary error is already
+    // caught and logged by connectToActualForSession; a secondary rejection escapes
+    // from the api worker's cleanup code with a non-enumerable error object, making
+    // reasonStr resolve to '[object Object]' rather than containing the code string.
+    // Check raw properties on the reason object as a fallback.
+    (reason as Record<string, unknown>)?.code === 'EACCES' ||
+    (reason as Record<string, unknown>)?.code === 'EPERM' ||
+    (typeof (reason as Record<string, unknown>)?.stack === 'string' &&
+      ((reason as Record<string, unknown>).stack as string).includes('download-budget'))
   ) {
     console.error('⚠️  Known Actual API domain error escaped to unhandledRejection:');
     console.error('⚠️  ' + reasonStr);


### PR DESCRIPTION
# actual-mcp-server PR: fix data dir EACCES crash

**Title:** `fix: prevent server crash when data dir is not writable`

**Target branch:** `develop` (in agigante80/actual-mcp-server)

**Fork branch:** `ForrestThump/actual-mcp-server:fix/data-dir-eacces-crash`

---

## Description

When `MCP_BRIDGE_DATA_DIR` points to a directory that exists but is not writable by the container user (for example, a Docker volume mounted from a root-owned host directory), `@actual-app/api` throws `EACCES` during budget download. The primary error is caught and logged by `connectToActualForSession` in `ActualConnectionPool`. However, the api worker emits a **secondary rejection** from its internal cleanup path as a plain object with non-enumerable properties. This makes `String(reason)` resolve to `[object Object]`, so none of the existing string-based allow-list checks in the `unhandledRejection` handler match. The handler falls through to `process.exit(1)`, crashing the container.

The same crash occurs for `EPERM` errors (same root cause, different OS).

This fix extends the allow-list to check raw properties on the reason object (`code === 'EACCES'` / `'EPERM'`) and adds a stack-frame check for `'download-budget'` as a fallback. This is consistent with the existing defence-in-depth pattern already in place for auth failures and bank-sync errors. The session init failure is already caught, logged, and surfaced to the MCP client before the secondary rejection fires, so suppressing the crash does not hide any information.

Fixes: no existing issue (new discovery).

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

---

## Testing

**Test Configuration:**
- Node.js version: v22.22.2
- `@actual-app/api` version: ^26.5.2
- Operating System: Linux (Debian, amd64)

**Reproduction steps:**

```bash
# Mount a root-owned directory as the data volume
docker run --rm \
  -e ACTUAL_SERVER_URL=https://your-actual-server \
  -e ACTUAL_PASSWORD=yourpassword \
  -e ACTUAL_BUDGET_SYNC_ID=your-sync-id \
  -e MCP_BRIDGE_DATA_DIR=/data \
  -v /root/actual-data:/data \
  ghcr.io/agigante80/actual-mcp-server:latest
```

Without fix: server crashes with `process.exit(1)` on every connection attempt, restarting in a loop.
With fix: server logs the `EACCES` error and continues running; subsequent connections succeed once the volume permissions are corrected.

**Pre-commit checks:**

```bash
npm run build                     # clean, no TypeScript errors
npm run test:adapter              # passed (adapter + concurrency + retry)
npm run test:unit-js              # passed (all unit and schema tests)
npm audit --audit-level=moderate  # 0 vulnerabilities
```

---

## Checklist

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have checked for and removed console.log statements

### Documentation
- [x] No documentation changes required (behaviour change only in error handler)

### Testing
- [x] I have tested the changes manually
- [x] New and existing unit tests pass locally with my changes

### Commits
- [x] My commits follow the Conventional Commits specification

### Dependencies
- [x] I have not added unnecessary dependencies

---

## Deployment Notes

- [x] Requires Docker image rebuild (if using the prebuilt image, wait for a new release)

No environment variable changes required. The fix is defensive only.

---

## Security Considerations

- [x] I have considered security implications of my changes
- [x] I have not introduced any security vulnerabilities

Suppressing these specific non-fatal rejections does not mask any real errors. The primary EACCES failure is still logged at `error` level by `ActualConnectionPool` before the secondary rejection fires.


## 📝 Additional Notes

None.

## 🤖 Auto-Merge

If you want this PR to be automatically merged when all checks pass:

- [ ] I want this PR to auto-merge (add `automerge` label)

**Note:** Auto-merge requires:
- ✅ All CI checks passing
- ✅ No merge conflicts
- ✅ Branch up-to-date with main
- ✅ Required approvals (if configured)

---

## For Reviewers

### Review Checklist

- [ ] Code follows project conventions
- [ ] Changes are well-documented
- [ ] Tests are adequate and passing
- [ ] No security concerns
- [ ] Performance is acceptable
- [ ] Breaking changes are documented
- [ ] Ready to merge

### Feedback

(Reviewers: Add your feedback here)
