### PR TITLE
fix(tools): give transactions_import txs an explicit array schema

### DIFF
--- a/src/tools/transactions_import.ts
+++ b/src/tools/transactions_import.ts
@@ -1,13 +1,37 @@
 import { z } from 'zod';
 import type { paths } from '../../generated/actual-client/types.js';
 import type { ToolDefinition } from '../../types/tool.d.js';
+import { CommonSchemas } from '../lib/schemas/common.js';
 import adapter from '../lib/actual-adapter.js';
 
-// Allow either an object with accountId and txs, or raw tx array/object — keep validation light
+// A single transaction to import. `date` and `amount` (cents) are required by the
+// Actual API; everything else is optional. `.passthrough()` keeps the tool flexible
+// for any extra fields @actual-app/api accepts (imported_payee, subtransactions, …),
+// preserving the original "light validation" intent — while still giving MCP clients
+// a concrete shape to serialise the array against (an empty `z.unknown()` schema does
+// not, which made this tool unusable from stdio clients).
+const ImportTransactionSchema = z
+  .object({
+    date: CommonSchemas.date,
+    amount: CommonSchemas.amountCents,
+    payee: CommonSchemas.payeeId.optional(),
+    payee_name: z.string().optional().describe('Payee name (alternative to payee ID)'),
+    category: CommonSchemas.categoryId.optional(),
+    notes: CommonSchemas.notes,
+    cleared: CommonSchemas.cleared,
+    imported_id: z.string().optional().describe('Stable external ID used for de-duplication/reconciliation'),
+  })
+  .passthrough();
+
 // NOTE: Wrapped in z.object() for LibreChat compatibility (requires type: "object")
 const InputSchema = z.object({
-  accountId: z.string().optional(),
-  txs: z.unknown(),
+  accountId: z
+    .string()
+    .optional()
+    .describe('Destination account ID to import into. Provide for normal bank-statement imports; omitting it can create transactions with no account.'),
+  txs: z
+    .array(ImportTransactionSchema)
+    .describe('Transactions to import. Each item requires `date` (YYYY-MM-DD) and `amount` (in cents). De-duplication is by `imported_id`.'),
 });
 
 // RESPONSE_TYPE: object


### PR DESCRIPTION
Fixes #217.

### Problem
`txs: z.unknown()` publishes as an empty `{}` JSON Schema, so stdio MCP clients (Claude Code / Claude Desktop) can't serialise the transaction array and the tool always fails with "`date` is required". The handler is fine; only the published schema is broken.

### Fix
Replace `txs: z.unknown()` with an explicit array of transaction items, reusing `CommonSchemas` for consistency with `transactions_create`:
- `date` + `amount` (cents) required per item (matches the Actual API).
- `payee` / `payee_name` / `category` / `notes` / `cleared` / `imported_id` optional.
- `.passthrough()` retains flexibility for any extra `@actual-app/api` fields — keeping the original "light validation" intent.
- Top-level stays `z.object` → LibreChat `type: object` compatibility preserved.

### Validation
- `tools/list` now publishes `txs` as `{type: "array", items: {…}}` with `required: ["txs"]`.
- End-to-end `tools/call actual_transactions_import` → `actual_transactions_delete` round-trip against a live budget succeeds (net-zero).
- No change to the handler or adapter.
