### PR TITLE
feat(auth): OIDC cross-origin JWKS support via OIDC_JWKS_TRUSTED_HOSTS (#254)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,6 +193,12 @@ MCP_BRIDGE_DATA_DIR=./actual-data
 # a wildcard. Leave empty unless your IdP needs it.
 # OIDC_ACCEPTED_AUDIENCES=my-client-id
 
+# Opt-in allowlist of JWKS hostnames permitted to differ from the issuer origin (#254).
+# Empty by default: a cross-origin JWKS fetch is refused. Required for Google, which
+# always serves JWKS from www.googleapis.com regardless of the issuer origin. Exact
+# hostname match only; no wildcards. Comma-separate multiple entries if needed.
+# OIDC_JWKS_TRUSTED_HOSTS=www.googleapis.com
+
 # Comma-separated required scopes (optional; tokens must have ALL listed)
 # OIDC_SCOPES=
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ All configuration is via environment variables. Copy `.env.example` to `.env` to
 | `OIDC_ALLOW_INSECURE_ISSUER` | `false` | No | Allow a plaintext (http) OIDC issuer on a trusted network (#244). Off by default (http issuer refused at startup); set `true` only for local/LAN testing |
 | `OIDC_RESOURCE` | _(none)_ | No | Expected `aud` claim in JWT (your client ID) |
 | `OIDC_ACCEPTED_AUDIENCES` | _(none)_ | No | Extra accepted `aud` values beyond `OIDC_RESOURCE`, comma-separated (#245). For IdPs that put the client-id in `aud` (e.g. Authentik). Strict allowlist, never a wildcard |
+| `OIDC_JWKS_TRUSTED_HOSTS` | _(none)_ | No | Hostnames allowed to serve JWKS from a different origin than the issuer (#254). Required for Google: `www.googleapis.com`. Exact match only, no wildcards |
 | `OIDC_SCOPES` | _(none)_ | No | Comma-separated required scopes; leave empty for Casdoor |
 | `AUTH_BUDGET_ACL` | _(none)_ | No | Per-user budget ACL; see [AI Client Setup](docs/guides/AI_CLIENT_SETUP.md#oidc-authentication-multi-user) |
 | `MCP_ENABLE_HTTPS` | `false` | No | Enable native TLS. Requires `MCP_HTTPS_CERT` and `MCP_HTTPS_KEY` |

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -67,6 +67,7 @@ Legend for **Source**: `schema` = validated Zod key; `raw` = read directly from
 | `OIDC_ALLOW_INSECURE_ISSUER` | bool string | `false` | No | no | schema | `httpServer.ts` | #244 opt-out: allow an http OIDC issuer on a trusted network (default refuses non-https/non-loopback issuers at startup) |
 | `OIDC_RESOURCE` | url string | (none) | No | no | schema | config | Expected `aud` claim |
 | `OIDC_ACCEPTED_AUDIENCES` | csv string | (none) | No | no | schema | `httpServer.ts` | #245 extra accepted `aud` values beyond `OIDC_RESOURCE` (strict allowlist; for IdPs that put the client-id in `aud`, e.g. Authentik) |
+| `OIDC_JWKS_TRUSTED_HOSTS` | csv string | (none) | No | no | schema | `oidc-discovery.ts` | #254 opt-in allowlist of hostnames permitted to serve JWKS from a different origin than the issuer. Empty by default (cross-origin JWKS fetch refused). Required for Google: `OIDC_JWKS_TRUSTED_HOSTS=www.googleapis.com`. Exact hostname match only; no wildcards |
 | `OIDC_SCOPES` | csv string | (none) | No | no | schema | config | Comma-separated required scopes |
 | `AUTH_BUDGET_ACL` | json string | (none) | No | no | schema | config | Per-user budget ACL map |
 | `MCP_ENABLE_HTTPS` | bool string | `false` | No | no | schema | config; also raw at `index.ts:277,286` | Native TLS switch (canonical TLS knob) |

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,6 +48,14 @@ export const configSchema = z.object({
   // Strict closed allowlist: the accepted set is OIDC_RESOURCE plus these; never a
   // wildcard. Default empty, so single-audience deployments are unchanged.
   OIDC_ACCEPTED_AUDIENCES: z.string().optional(),
+  // #254: opt-in allowlist of hostnames permitted to serve JWKS from a different
+  // origin than the issuer. Empty by default (cross-origin JWKS fetch refused).
+  // Required for Google (OIDC_ISSUER=https://accounts.google.com whose jwks_uri is
+  // https://www.googleapis.com/oauth2/v3/certs). Exact hostname match only; no
+  // wildcards or substrings. Trailing comma / whitespace-only entries are ignored.
+  OIDC_JWKS_TRUSTED_HOSTS: z.string().optional().transform(
+    (val) => val?.split(',').map((h) => h.trim().toLowerCase()).filter(Boolean) ?? [],
+  ),
   // Comma-separated required scopes (e.g. "read,write"). Optional.
   OIDC_SCOPES: z.string().optional(),
   // JSON map of principal → budget sync-ID list for per-user budget ACL.

--- a/src/lib/oidc-discovery.ts
+++ b/src/lib/oidc-discovery.ts
@@ -1,7 +1,7 @@
 import { createModuleLogger } from './loggerFactory.js';
 
 /**
- * OIDC JWKS discovery (#244).
+ * OIDC JWKS discovery (#244, #254).
  *
  * Background: the OIDC verifier used to build its key set from a hardcoded
  * `${OIDC_ISSUER}/.well-known/jwks`, which is wrong for most identity providers
@@ -15,8 +15,8 @@ import { createModuleLogger } from './loggerFactory.js';
  *   - the resolved `jwks_uri` must be https and on the SAME host as the issuer, so
  *     a tampered or misconfigured discovery document cannot point key fetching at
  *     an attacker-controlled host. Cross-host issuers (for example Google, which
- *     serves keys from googleapis.com) are intentionally not auto-trusted; that is
- *     a separate, configurable follow-up (#245).
+ *     serves keys from googleapis.com) are intentionally not auto-trusted; they
+ *     require the operator to explicitly set OIDC_JWKS_TRUSTED_HOSTS (#254).
  *
  * The pure helpers (assertSecureIssuer, resolveJwksUri) are unit-tested without a
  * network; discoverJwksUri wraps them around a single startup fetch and fails
@@ -71,12 +71,14 @@ export function assertSecureIssuer(issuer: string | undefined, allowInsecure = f
 /**
  * Pure: resolve and validate the `jwks_uri` from a parsed discovery document
  * against the issuer. Throws (fail closed) if it is missing, not https, carries
- * embedded credentials, or is not same-origin (scheme + host + port) with the issuer.
+ * embedded credentials, or is not same-origin (scheme + host + port) with the
+ * issuer -- unless the JWKS hostname is in `trustedHosts` (#254).
  */
 export function resolveJwksUri(
   discoveryDoc: { jwks_uri?: unknown } | null | undefined,
   issuer: string | undefined,
   allowInsecure = false,
+  trustedHosts: string[] = [],
 ): string {
   const issuerUrl = assertSecureIssuer(issuer, allowInsecure);
   if (!discoveryDoc || typeof discoveryDoc !== 'object') {
@@ -102,9 +104,15 @@ export function resolveJwksUri(
   // same host is a different service, so comparing origins keeps the guarantee the
   // security review asked for. Both are https here, so this is effectively host+port.
   if (jwks.origin.toLowerCase() !== issuerUrl.origin.toLowerCase()) {
-    throw new Error(
-      `OIDC "jwks_uri" origin (${jwks.origin}) does not match the issuer origin (${issuerUrl.origin}); ` +
-        'refusing a cross-origin key fetch. A cross-host issuer (e.g. Google) needs an explicit trusted-host allowlist (#245).',
+    const jwksHostname = jwks.hostname.toLowerCase();
+    if (!trustedHosts.includes(jwksHostname)) {
+      throw new Error(
+        `OIDC "jwks_uri" origin (${jwks.origin}) does not match the issuer origin (${issuerUrl.origin}); ` +
+          'refusing a cross-origin key fetch. A cross-host issuer (e.g. Google) needs an explicit trusted-host allowlist (#254).',
+      );
+    }
+    logger.info(
+      `[OIDC] Cross-host JWKS fetch allowed for ${jwksUri} (host "${jwksHostname}" in OIDC_JWKS_TRUSTED_HOSTS)`,
     );
   }
   return jwks.toString();
@@ -118,6 +126,7 @@ export function resolveJwksUri(
 export async function discoverJwksUri(
   issuer: string | undefined,
   allowInsecure = false,
+  trustedHosts: string[] = [],
   fetchImpl: typeof fetch = fetch,
 ): Promise<string> {
   assertSecureIssuer(issuer, allowInsecure);
@@ -142,7 +151,7 @@ export async function discoverJwksUri(
   } catch {
     throw new Error(`OIDC discovery document at ${discoveryUrl} is not valid JSON`);
   }
-  const jwksUri = resolveJwksUri(doc as { jwks_uri?: unknown }, issuer, allowInsecure);
+  const jwksUri = resolveJwksUri(doc as { jwks_uri?: unknown }, issuer, allowInsecure, trustedHosts);
   logger.info('Resolved JWKS URI from OIDC discovery', { jwksUri });
   return jwksUri;
 }

--- a/src/server/httpServer.ts
+++ b/src/server/httpServer.ts
@@ -101,7 +101,7 @@ export async function startHttpServer(
       // closed on a non-https issuer, a cross-origin redirect, a missing/invalid
       // jwks_uri, or a jwks_uri on a different host than the issuer. jose's
       // createRemoteJWKSet then fetches the keys lazily and caches them.
-      const jwksUri = await discoverJwksUri(config.OIDC_ISSUER, config.OIDC_ALLOW_INSECURE_ISSUER);
+      const jwksUri = await discoverJwksUri(config.OIDC_ISSUER, config.OIDC_ALLOW_INSECURE_ISSUER, config.OIDC_JWKS_TRUSTED_HOSTS);
       const jwks = createRemoteJWKSet(new URL(jwksUri));
       const customJwtVerify = async (token: string) => {
         // Enforce the audience claim (#160, OWASP A07). Without it, any

--- a/tests/unit/httpServer_oidc_jwks_discovery.test.js
+++ b/tests/unit/httpServer_oidc_jwks_discovery.test.js
@@ -49,6 +49,50 @@ check('accepts a same-origin jwks_uri with a matching explicit port', () => {
 });
 check('rejects a jwks_uri with embedded credentials', () => throws(() => resolveJwksUri({ jwks_uri: 'https://user:pass@idp.example.com/keys' }, 'https://idp.example.com'), /embedded credentials/));
 
+console.log('\n[oidc-jwks-discovery] resolveJwksUri trusted-host allowlist (#254)');
+check('trusted host listed: cross-origin JWKS allowed', () => {
+  const got = resolveJwksUri({ jwks_uri: 'https://jwks.external.com/keys' }, 'https://idp.example.com', false, ['jwks.external.com']);
+  assert.strictEqual(got, 'https://jwks.external.com/keys');
+});
+check('trusted host not listed: cross-origin JWKS rejected', () => throws(
+  () => resolveJwksUri({ jwks_uri: 'https://jwks.external.com/keys' }, 'https://idp.example.com', false, ['other.com']),
+  /does not match the issuer origin/,
+));
+check('empty allowlist (default): cross-origin JWKS rejected (regression guard)', () => throws(
+  () => resolveJwksUri({ jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs' }, 'https://accounts.google.com'),
+  /does not match the issuer origin/,
+));
+check('Google-style setup: trusted host allows googleapis.com', () => {
+  const got = resolveJwksUri(
+    { jwks_uri: 'https://www.googleapis.com/oauth2/v3/certs' },
+    'https://accounts.google.com',
+    false,
+    ['www.googleapis.com'],
+  );
+  assert.strictEqual(got, 'https://www.googleapis.com/oauth2/v3/certs');
+});
+check('trailing comma in env var (empty entry filtered): only real hostname trusted', () => {
+  const hosts = 'jwks.external.com,'.split(',').map(h => h.trim().toLowerCase()).filter(Boolean);
+  assert.deepStrictEqual(hosts, ['jwks.external.com']);
+  const got = resolveJwksUri({ jwks_uri: 'https://jwks.external.com/keys' }, 'https://idp.example.com', false, hosts);
+  assert.strictEqual(got, 'https://jwks.external.com/keys');
+});
+check('whitespace-only entry (entry filtered): only real hostname trusted', () => {
+  const hosts = ' , jwks.external.com'.split(',').map(h => h.trim().toLowerCase()).filter(Boolean);
+  assert.deepStrictEqual(hosts, ['jwks.external.com']);
+  const got = resolveJwksUri({ jwks_uri: 'https://jwks.external.com/keys' }, 'https://idp.example.com', false, hosts);
+  assert.strictEqual(got, 'https://jwks.external.com/keys');
+});
+check('exact hostname match required: subdomain of trusted host is rejected', () => throws(
+  () => resolveJwksUri({ jwks_uri: 'https://sub.jwks.external.com/keys' }, 'https://idp.example.com', false, ['jwks.external.com']),
+  /does not match the issuer origin/,
+));
+check('source assertion: OIDC_JWKS_TRUSTED_HOSTS appears in resolveJwksUri implementation', () => {
+  const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), '../../src/lib/oidc-discovery.ts'), 'utf8');
+  assert.ok(src.includes('OIDC_JWKS_TRUSTED_HOSTS'), 'expected OIDC_JWKS_TRUSTED_HOSTS referenced in oidc-discovery.ts');
+  assert.ok(src.includes('trustedHosts'), 'expected trustedHosts parameter in resolveJwksUri');
+});
+
 console.log('\n[oidc-jwks-discovery] assertSecureIssuer (downgrade guard)');
 check('https issuer ok', () => { assertSecureIssuer('https://idp.example.com'); });
 check('loopback http issuer ok (local dev)', () => { assertSecureIssuer('http://localhost:8080'); });


### PR DESCRIPTION
## Summary

- Adds opt-in env var `OIDC_JWKS_TRUSTED_HOSTS` (empty by default, comma-separated hostnames) that permits cross-origin JWKS fetches when the operator explicitly allowlists the host
- Required for Google (`OIDC_ISSUER=https://accounts.google.com`), which always serves JWKS from `www.googleapis.com` regardless of issuer origin
- Default behavior is unchanged: cross-origin JWKS fetch is refused unless a host is explicitly listed
- Exact hostname match only; no wildcards, substrings, or globs
- Follows the same split/trim/filter-empties pattern as `OIDC_ACCEPTED_AUDIENCES` (#245)

## Files changed

| File | Change |
|---|---|
| `src/config.ts` | New `OIDC_JWKS_TRUSTED_HOSTS` field with CSV-to-array transform |
| `src/lib/oidc-discovery.ts` | `resolveJwksUri` and `discoverJwksUri` accept `trustedHosts[]`; consult it before throwing cross-origin error; log info when allowed |
| `src/server/httpServer.ts` | Pass `config.OIDC_JWKS_TRUSTED_HOSTS` to `discoverJwksUri` |
| `.env.example` | Document new env var with Google example |
| `docs/CONFIGURATION.md` | Add row to OIDC section |
| `README.md` | Add row to env table |
| `tests/unit/httpServer_oidc_jwks_discovery.test.js` | 8 new cases: trusted allowed, not listed, empty default regression guard, Google-style, trailing comma, whitespace entry, subdomain rejection, source assertion |

## Test plan

- [x] Build compiles cleanly (`npm run build`)
- [x] All 42 tests in `httpServer_oidc_jwks_discovery.test.js` pass
- [x] Config-drift passes: 44 documented vars consistent across schema, `.env.example`, and README
- [x] Pre-existing `npm audit` finding (`hono`) is not introduced by this PR

## Acceptance criteria covered

- With `OIDC_JWKS_TRUSTED_HOSTS` unset, behavior is byte-for-byte identical to today (regression guard test)
- A listed cross-origin JWKS host is allowed and logs an info line
- An unlisted cross-origin host is still rejected with the existing error
- Exact hostname match only: `sub.jwks.external.com` is rejected when only `jwks.external.com` is listed
- Trailing comma and whitespace-only entries are filtered; empty string is never added to the list
- `docs/CONFIGURATION.md` and README updated; `npm run config-drift` passes

Closes #254

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01TUNHvtSRjsSk3h56nYAqrL