### PR TITLE
feat: add JMT x402 Agent Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,3 +728,5 @@ The software is provided **as-is**, without warranty of any kind. The author acc
 ---
 
 **Version:** 0.8.13 | **Tool Count:** 71 (verified LibreChat-compatible)
+
+- [JMT x402 Agent Tools](https://jmt-x402-proxy.jmthomasofficial.workers.dev) — 25 paid x402 endpoints on Base mainnet: web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard. $0.001-$0.15/call USDC. Local LLM-powered.


### PR DESCRIPTION
## What\n\nAdds JMT x402 Agent Tools — 25 paid x402 endpoints on Base mainnet.\n\n## Service Details\n\n- **URL:** https://jmt-x402-proxy.jmthomasofficial.workers.dev\n- **Network:** Base mainnet (eip155:8453)\n- **Endpoints:** 25 paid endpoints covering web search, AI analysis, crypto/stock data, SEC filings, company intel, news, sentiment, macro dashboard\n- **Price range:** $0.001-$0.15 per call\n- **Currency:** USDC on Base\n- **Wallet:** 0x624FaF18C78456C8Da5bf156Cd77c1A2033F21c5\n- **Discovery:** /.well-known/x402, /openapi.json, /llms.txt\n\n## Verification\n\n- [x] curl -I https://jmt-x402-proxy.jmthomasofficial.workers.dev/api/search returns 402\n- [x] /.well-known/x402 returns valid x402 discovery document\n- [x] /openapi.json has x-payment-info on all paid operations